### PR TITLE
step3 optimization&tests

### DIFF
--- a/src/rcpp_retrofit_step3.cpp
+++ b/src/rcpp_retrofit_step3.cpp
@@ -2,7 +2,7 @@
 using namespace Rcpp;
 
 // [[Rcpp::export]]
-NumericVector phi_alpha_numerator(NumericVector W_gk, NumericVector TH_k, NumericVector H_ks, float lambda) {
+NumericVector retrofit_step3_alpha_numerator(NumericVector W_gk, NumericVector TH_k, NumericVector H_ks, float lambda) {
   /* Equivalent code
    * for(s in 1:S){
    *  for(k in 1:K){
@@ -25,10 +25,6 @@ NumericVector phi_alpha_numerator(NumericVector W_gk, NumericVector TH_k, Numeri
   for(int s=0; s<S; ++s){
     for(int k=0; k<K; ++k){
       for(int g=0; g<G; ++g){
-        // w = W_gk[(k*G+g)];
-        // th = TH_k[k];
-        // h = H_ks[(s*K+k)];
-        // phi_a_gks[idx] = (w*th + lambda)*h;
         phi_a_gks[idx] = (W_gk[(k*G+g)]*TH_k[k] + lambda)*H_ks[(s*K+k)];
         idx++;
       }
@@ -39,7 +35,7 @@ NumericVector phi_alpha_numerator(NumericVector W_gk, NumericVector TH_k, Numeri
 }
 
 // [[Rcpp::export]]
-NumericVector phi_alpha_denominator(NumericVector phi_a_gks) {
+NumericVector retrofit_step3_alpha_denominator(NumericVector phi_a_gks) {
 /* Equivalent code
  * for(s in 1:S){
  *  for(v in 1:G){
@@ -79,3 +75,102 @@ NumericVector phi_alpha_denominator(NumericVector phi_a_gks) {
   return phi_a_gks;
 }
 
+// [[Rcpp::export]]
+NumericVector retrofit_step3_alpha(NumericVector W_gk, NumericVector TH_k, NumericVector H_ks, float lambda) {
+  /* Equivalent code
+   * for(s in 1:S){
+   *  for(k in 1:K){
+   *    phi_a_gks[,k,s]=((W_gk[,k] * TH_k[k]) +lamda)* H_ks[k,s]
+   *  }
+   * }
+   * for(s in 1:S){
+   *  for(v in 1:G){
+   *    phi_a_gks[v,,s]=phi_a_gks[v,,s]/sum(phi_a_gks[v,,s])
+   *  }
+   * }
+   */
+  //dimensions
+  // W_gk:(G,K), TH_K:(K), H_ks:(K,S)
+  NumericVector dim_w = W_gk.attr("dim");
+  int G = dim_w[0];
+  int K = dim_w[1];
+  NumericVector dim_h = H_ks.attr("dim");
+  int S = dim_h[1];
+  
+  
+  //Calculate numerator part
+  int idx = 0;
+  NumericVector phi_a_gks (G*K*S);
+  for(int s=0; s<S; ++s){
+    for(int k=0; k<K; ++k){
+      for(int g=0; g<G; ++g){
+        phi_a_gks[idx] = (W_gk[(k*G+g)]*TH_k[k] + lambda)*H_ks[(s*K+k)];
+        idx++;
+      }
+    }
+  }
+  
+  //Calculate second dimension sums
+  idx = 0;
+  NumericVector sums (G*S);
+  for(int s=0; s<S; ++s){
+    for(int k=0; k<K; ++k){
+      for(int g=0; g<G; ++g){
+        sums[(s*G+g)] += phi_a_gks[idx];
+        idx++;
+      }
+    }
+  }
+  
+  //Calculate denominator part
+  idx = 0;
+  for(int s=0; s<S; ++s){
+    for(int k=0; k<K; ++k){
+      for(int g=0; g<G; ++g){
+        phi_a_gks[idx] = phi_a_gks[idx]/sums[(s*G+g)];
+        idx++;
+      }
+    }
+  }
+  return phi_a_gks;
+}
+
+
+// [[Rcpp::export]]
+NumericVector retrofit_step3_beta(NumericVector W_gk, NumericVector TH_k, float lambda) {
+  /* Equivalent code
+   * for(k in 1:K){
+   *  for(v in 1:G){
+   *    if((W_gk[v,k]*TH_k[k] + lamda)==0){
+   *      phi_b_gk[v,k]=1 ## to avoid numerical error of 0/0 when lamda=0
+   *    } else {
+   *      phi_b_gk[v,k]=(W_gk[v,k]*TH_k[k])/(W_gk[v,k]*TH_k[k] + lamda)
+   *    }
+   *  }
+   * }
+   */
+  //dimensions
+  // W_gk:(G,K), TH_K:(K)
+  NumericVector dim_w = W_gk.attr("dim");
+  int G = dim_w[0];
+  int K = dim_w[1];
+  
+  int idx = 0;
+  float w = 0;
+  float th = 0;
+  NumericVector phi_b_gk (G*K);
+  for(int k=0; k<K; ++k){
+    for(int g=0; g<G; ++g){
+      w = W_gk[(k*G+g)];
+      th = TH_k[k];
+      if((w*th + lambda)==0){
+        phi_b_gk[idx]=1; // to avoid numerical error of 0/0 when lambda=0
+      } else {
+        phi_b_gk[idx]=(w*th)/(w*th + lambda);
+      }
+      idx++;
+    }
+  }
+  
+  return phi_b_gk;
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(retrofit)
+
+test_check("retrofit")

--- a/tests/testthat/test-refactoring-retrofit-step3.R
+++ b/tests/testthat/test-refactoring-retrofit-step3.R
@@ -1,0 +1,69 @@
+test_that("step3-alpha-numerator", {
+  G = 4
+  K = 3
+  S = 2
+  W_gk=matrix(runif(G*K, 0, 10),nrow=G, ncol=K)
+  H_ks=matrix(runif(K*S, 0, 10),nrow=K, ncol=S)
+  TH_k=array(runif(K, 0, 10))
+  lambda = runif(1, 0, 1)
+  
+  # r code
+  phi_a_gks=array(rep(0,G*K*S), c(G,K,S))
+  for(s in 1:S){
+    for(k in 1:K){
+      phi_a_gks[,k,s] = ((W_gk[,k] * TH_k[k]) +lambda)* H_ks[k,s]
+    }
+  }
+  
+  # rcpp code
+  phi_a_gks_new = array(retrofit_step3_alpha_numerator(W_gk, TH_k, H_ks, lambda), c(G,K,S));
+  
+  expect_true(all.equal(phi_a_gks, phi_a_gks_new, tolerance=1e-4))
+})
+
+test_that("step3-alpha-denominator", {
+  G = 4
+  K = 3
+  S = 2
+  sample=array(runif(G*K*S, 0, 10), c(G,K,S))
+  
+  # r code
+  phi_a_gks <- sample
+  for(s in 1:S){
+    for(v in 1:G){
+      phi_a_gks[v,,s]=phi_a_gks[v,,s]/sum(phi_a_gks[v,,s])
+    }
+  }
+  
+  # rcpp code
+  phi_a_gks_new <- sample
+  phi_a_gks_new = array(retrofit_step3_alpha_denominator(phi_a_gks_new), c(G,K,S));
+  
+  # test: all elements are same
+  expect_true(all.equal(phi_a_gks, phi_a_gks_new, tolerance=1e-4))
+})
+
+test_that("step3-beta", {
+  G = 4
+  K = 3
+  W_gk=matrix(runif(G*K, 0, 10),nrow=G, ncol=K)
+  TH_k=array(runif(K, 0, 10))
+  lambda = runif(1, 0, 1)
+  
+  # r code
+  phi_b_gk=array(rep(0,G*K), c(G,K))
+  for(k in 1:K){
+    for(v in 1:G){
+      if((W_gk[v,k]*TH_k[k] + lambda)==0){
+        phi_b_gk[v,k]=1 ## to avoid numerical error of 0/0 when lambda=0
+      } else {
+        phi_b_gk[v,k]=(W_gk[v,k]*TH_k[k])/(W_gk[v,k]*TH_k[k] + lambda)
+      }
+    }
+  }
+  
+  # rcpp code
+  phi_b_gk_new = array(retrofit_step3_beta(W_gk, TH_k, lambda), c(G,K));
+  
+  expect_true(all.equal(phi_b_gk, phi_b_gk_new, tolerance=1e-4))
+})


### PR DESCRIPTION
1. Rcpp codes are added in rcpp_retrofit_step3.cpp
I commented Roopali's "Equivalent code" in each function to compare codes.

2. Rcpp codes are tested with original codes in test-refactoring-retrofit-step3.R
Each test contains original r codes and new rcpp codes to compare their output equality.

3. Performance
phi-alpha calculation: 4.3xxx -> 0.1xxx
phi-beta calculation: 0.009 -> 0.00
[1] "Iteration 1"
[1] "step3-alpha-original:  4.383 Seconds"
[1] "step3-alpha-rcpp:  0.303 Seconds"
[1] "step3-beta-original:  0.009 Seconds"
[1] "step3-beta-rcpp:  0 Seconds"
[1] "Iteration 2"
[1] "step3-alpha-original:  4.323 Seconds"
[1] "step3-alpha-rcpp:  0.128 Seconds"
[1] "step3-beta-original:  0.009 Seconds"
[1] "step3-beta-rcpp:  0 Seconds"
[1] "Iteration 3"
[1] "step3-alpha-original:  4.326 Seconds"
[1] "step3-alpha-rcpp:  0.119 Seconds"
[1] "step3-beta-original:  0.009 Seconds"
[1] "step3-beta-rcpp:  0 Seconds"

4. Potential issue
In the testing, I had to adjust tolerance (1e-4) because the outputs were slightly different between the original and new codes. I haven't analyzed the reason.
e.g. expect_true(all.equal(phi_a_gks, phi_a_gks_new, tolerance=1e-4))
