### PR TITLE
Test reproducibility

### DIFF
--- a/R/retrofit.R
+++ b/R/retrofit.R
@@ -10,6 +10,7 @@
 #'
 #' 
 retrofit <- function(x, iterations=4000) {
+  set.seed(1)
   # if(!is.matrix(x)) stop("x must be a matrix with shape: GeneExpressions:Spots")
   # the first column is the row names
   rownames(x)=x[,1]
@@ -27,16 +28,16 @@ retrofit <- function(x, iterations=4000) {
   beta_W_0=0.0001 
   alpha_H_0=0.2 
   beta_H_0=0.2
-  alpha_TH_0=10/K
+  alpha_TH_0=10/cell_types
   beta_TH_0=10
   lamda=0.01
   # parameter matrices
+  alpha_TH_k=runif(K,0,1)+alpha_TH_0
+  beta_TH_k=runif(K,0,1)+beta_TH_0
   alpha_W_gk=matrix(runif(G*K,0,0.5)+alpha_W_0 , nrow=G, ncol=K)
   beta_W_gk=matrix(runif(G*K,0,0.005)+beta_W_0 , nrow=G, ncol=K)
   alpha_H_ks=matrix(runif(K*S,0,0.1)+alpha_H_0 , nrow=K, ncol=S)
   beta_H_ks=matrix(runif(K*S,0,0.5)+beta_H_0 , nrow=K, ncol=S)
-  alpha_TH_k=runif(K,0,1)+alpha_TH_0
-  beta_TH_k=runif(K,0,1)+beta_TH_0
   # variational parameters
   phi_a_gks=array(rep(0,G*K*S), c(G,K,S))
   phi_b_gk=matrix(0, nrow=G, ncol=K)

--- a/R/retrofit_original.R
+++ b/R/retrofit_original.R
@@ -4,6 +4,7 @@
 
 ### Read synthetic data
 retrofit_original <- function(X, iterations=4000) {
+  set.seed(1)
   # X=read.csv("A3_counts_G=1554.csv") # change this to other ST data
   rownames(X)=X[,1]
   X=as.matrix(X[,-1])

--- a/tests/testthat/test-refactoring-reproducibility.R
+++ b/tests/testthat/test-refactoring-reproducibility.R
@@ -1,0 +1,18 @@
+test_that("reproducibility", {
+  dir = "~/Research/retrofit/retrofit/results"
+  file="A3_1554"
+  paths_original = retrofit_simulation_original(dir, file, iterations=100)
+  paths = retrofit_simulation(dir, file, iterations=100)
+  
+  w_original=read.csv(paths_original$out_w_path)
+  h_original=read.csv(paths_original$out_h_path)
+  t_original=read.csv(paths_original$out_t_path)
+  
+  w=read.csv(paths$out_w_path)
+  h=read.csv(paths$out_h_path)
+  t=read.csv(paths$out_t_path)
+  
+  expect_true(all.equal(w_original, w))
+  expect_true(all.equal(h_original, h))
+  expect_true(all.equal(t_original, t))
+})


### PR DESCRIPTION
1. Add set.seed(1) for randomized variables control
We have retrofit.R and retrofit_original.R that contains new and roopali's retrofit algorithm, respectively.
I added set.seed(1) at both functions to control randomized variables.

2. Build reproducibility test
test-refactoring-reproducibility.R calls each retrofit_simulation.R and retrofit_simulation_original.R to compare their results.

3. Fix parts that are invoking different outputs
The test failed at initial attempts.
I figured out two parts that are contributing to the different results.
First, I made a mistake at the line "alpha_TH_0=10/K". I did not regard the fact that the context of K is different in the new algorithm that it holds twice larger (8->16) value.
Second, it wasn't a fault but related to set.seed(1) adjustment. I moved some lines that are containing "runif" (e.g. "alpha_TH_k=runif(K,0,1)+alpha_TH_0") so its assigned value became different between new and old algorithms even though set.seed(1) was used.  

Now the test passes and our framework is ready for further optimization.
![image](https://user-images.githubusercontent.com/90921267/173957644-55d17a8f-4410-46b6-b1c3-32904eadee5d.png)
