### PR TITLE
Calibrate differences between original&optimized (float => decimal)

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -23,14 +23,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // retrofit_step3_alpha_numerator
-void retrofit_step3_alpha_numerator(NumericVector W_gk, NumericVector TH_k, NumericVector H_ks, float lambda, NumericVector out_phi_a_gks);
+void retrofit_step3_alpha_numerator(NumericVector W_gk, NumericVector TH_k, NumericVector H_ks, double lambda, NumericVector out_phi_a_gks);
 RcppExport SEXP _retrofit_retrofit_step3_alpha_numerator(SEXP W_gkSEXP, SEXP TH_kSEXP, SEXP H_ksSEXP, SEXP lambdaSEXP, SEXP out_phi_a_gksSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericVector >::type W_gk(W_gkSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type TH_k(TH_kSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type H_ks(H_ksSEXP);
-    Rcpp::traits::input_parameter< float >::type lambda(lambdaSEXP);
+    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type out_phi_a_gks(out_phi_a_gksSEXP);
     retrofit_step3_alpha_numerator(W_gk, TH_k, H_ks, lambda, out_phi_a_gks);
     return R_NilValue;
@@ -47,34 +47,34 @@ BEGIN_RCPP
 END_RCPP
 }
 // retrofit_step3_alpha
-void retrofit_step3_alpha(NumericVector W_gk, NumericVector TH_k, NumericVector H_ks, float lambda, NumericVector out_phi_a_gks);
+void retrofit_step3_alpha(NumericVector W_gk, NumericVector TH_k, NumericVector H_ks, double lambda, NumericVector out_phi_a_gks);
 RcppExport SEXP _retrofit_retrofit_step3_alpha(SEXP W_gkSEXP, SEXP TH_kSEXP, SEXP H_ksSEXP, SEXP lambdaSEXP, SEXP out_phi_a_gksSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericVector >::type W_gk(W_gkSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type TH_k(TH_kSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type H_ks(H_ksSEXP);
-    Rcpp::traits::input_parameter< float >::type lambda(lambdaSEXP);
+    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type out_phi_a_gks(out_phi_a_gksSEXP);
     retrofit_step3_alpha(W_gk, TH_k, H_ks, lambda, out_phi_a_gks);
     return R_NilValue;
 END_RCPP
 }
 // retrofit_step3_beta
-void retrofit_step3_beta(NumericVector W_gk, NumericVector TH_k, float lambda, NumericVector out_phi_b_gk);
+void retrofit_step3_beta(NumericVector W_gk, NumericVector TH_k, double lambda, NumericVector out_phi_b_gk);
 RcppExport SEXP _retrofit_retrofit_step3_beta(SEXP W_gkSEXP, SEXP TH_kSEXP, SEXP lambdaSEXP, SEXP out_phi_b_gkSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericVector >::type W_gk(W_gkSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type TH_k(TH_kSEXP);
-    Rcpp::traits::input_parameter< float >::type lambda(lambdaSEXP);
+    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type out_phi_b_gk(out_phi_b_gkSEXP);
     retrofit_step3_beta(W_gk, TH_k, lambda, out_phi_b_gk);
     return R_NilValue;
 END_RCPP
 }
 // retrofit_step4_alpha_calculation
-List retrofit_step4_alpha_calculation(NumericVector x_gs, NumericVector phi_a_gks, NumericVector phi_b_gk, float alpha_w_0, float alpha_h_0, float alpha_th_0);
+List retrofit_step4_alpha_calculation(NumericVector x_gs, NumericVector phi_a_gks, NumericVector phi_b_gk, double alpha_w_0, double alpha_h_0, double alpha_th_0);
 RcppExport SEXP _retrofit_retrofit_step4_alpha_calculation(SEXP x_gsSEXP, SEXP phi_a_gksSEXP, SEXP phi_b_gkSEXP, SEXP alpha_w_0SEXP, SEXP alpha_h_0SEXP, SEXP alpha_th_0SEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -82,15 +82,15 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericVector >::type x_gs(x_gsSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type phi_a_gks(phi_a_gksSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type phi_b_gk(phi_b_gkSEXP);
-    Rcpp::traits::input_parameter< float >::type alpha_w_0(alpha_w_0SEXP);
-    Rcpp::traits::input_parameter< float >::type alpha_h_0(alpha_h_0SEXP);
-    Rcpp::traits::input_parameter< float >::type alpha_th_0(alpha_th_0SEXP);
+    Rcpp::traits::input_parameter< double >::type alpha_w_0(alpha_w_0SEXP);
+    Rcpp::traits::input_parameter< double >::type alpha_h_0(alpha_h_0SEXP);
+    Rcpp::traits::input_parameter< double >::type alpha_th_0(alpha_th_0SEXP);
     rcpp_result_gen = Rcpp::wrap(retrofit_step4_alpha_calculation(x_gs, phi_a_gks, phi_b_gk, alpha_w_0, alpha_h_0, alpha_th_0));
     return rcpp_result_gen;
 END_RCPP
 }
 // retrofit_step4_beta_calculation
-List retrofit_step4_beta_calculation(NumericVector W_gk, NumericVector H_ks, NumericVector TH_k, float beta_w_0, float beta_h_0, float beta_th_0, float lambda);
+List retrofit_step4_beta_calculation(NumericVector W_gk, NumericVector H_ks, NumericVector TH_k, double beta_w_0, double beta_h_0, double beta_th_0, double lambda);
 RcppExport SEXP _retrofit_retrofit_step4_beta_calculation(SEXP W_gkSEXP, SEXP H_ksSEXP, SEXP TH_kSEXP, SEXP beta_w_0SEXP, SEXP beta_h_0SEXP, SEXP beta_th_0SEXP, SEXP lambdaSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -98,23 +98,23 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericVector >::type W_gk(W_gkSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type H_ks(H_ksSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type TH_k(TH_kSEXP);
-    Rcpp::traits::input_parameter< float >::type beta_w_0(beta_w_0SEXP);
-    Rcpp::traits::input_parameter< float >::type beta_h_0(beta_h_0SEXP);
-    Rcpp::traits::input_parameter< float >::type beta_th_0(beta_th_0SEXP);
-    Rcpp::traits::input_parameter< float >::type lambda(lambdaSEXP);
+    Rcpp::traits::input_parameter< double >::type beta_w_0(beta_w_0SEXP);
+    Rcpp::traits::input_parameter< double >::type beta_h_0(beta_h_0SEXP);
+    Rcpp::traits::input_parameter< double >::type beta_th_0(beta_th_0SEXP);
+    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
     rcpp_result_gen = Rcpp::wrap(retrofit_step4_beta_calculation(W_gk, H_ks, TH_k, beta_w_0, beta_h_0, beta_th_0, lambda));
     return rcpp_result_gen;
 END_RCPP
 }
 // retrofit_step5_parameter_estimation
-NumericVector retrofit_step5_parameter_estimation(NumericVector original, NumericVector update, float rho);
+NumericVector retrofit_step5_parameter_estimation(NumericVector original, NumericVector update, double rho);
 RcppExport SEXP _retrofit_retrofit_step5_parameter_estimation(SEXP originalSEXP, SEXP updateSEXP, SEXP rhoSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< NumericVector >::type original(originalSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type update(updateSEXP);
-    Rcpp::traits::input_parameter< float >::type rho(rhoSEXP);
+    Rcpp::traits::input_parameter< double >::type rho(rhoSEXP);
     rcpp_result_gen = Rcpp::wrap(retrofit_step5_parameter_estimation(original, update, rho));
     return rcpp_result_gen;
 END_RCPP

--- a/src/rcpp_retrofit_step3.cpp
+++ b/src/rcpp_retrofit_step3.cpp
@@ -5,7 +5,7 @@ using namespace Rcpp;
 void retrofit_step3_alpha_numerator(NumericVector W_gk, 
                                     NumericVector TH_k, 
                                     NumericVector H_ks, 
-                                    float lambda,
+                                    double lambda,
                                     NumericVector out_phi_a_gks) {
   /* Equivalent code
    * for(s in 1:S){
@@ -58,7 +58,7 @@ void retrofit_step3_alpha_numerator(NumericVector W_gk,
     ++TH_k_iter;
   }
   mul_gk_iter = mul_gk.begin();
-  float H_ks_val;
+  double H_ks_val;
   for(int s=0; s<S; ++s){
     for(int k=0; k<K; ++k){
       H_ks_val = *H_ks_iter;
@@ -124,7 +124,7 @@ void retrofit_step3_alpha_denominator(NumericVector out_phi_a_gks) {
 void retrofit_step3_alpha(NumericVector W_gk, 
                           NumericVector TH_k, 
                           NumericVector H_ks, 
-                          float lambda,
+                          double lambda,
                           NumericVector out_phi_a_gks) {
   /* Equivalent code
    * for(s in 1:S){
@@ -166,7 +166,7 @@ void retrofit_step3_alpha(NumericVector W_gk,
   }
   // numerator variables
   mul_gk_iter = mul_gk.begin();
-  float H_ks_val;
+  double H_ks_val;
   // denominator variables
   NumericVector sums (G*S);
   NumericVector::iterator sums_iter = sums.begin();
@@ -224,7 +224,7 @@ void retrofit_step3_alpha(NumericVector W_gk,
 // [[Rcpp::export]]
 void retrofit_step3_beta(NumericVector W_gk, 
                          NumericVector TH_k, 
-                         float lambda,
+                         double lambda,
                          NumericVector out_phi_b_gk) {
   /* Equivalent code
    * for(k in 1:K){
@@ -244,8 +244,8 @@ void retrofit_step3_beta(NumericVector W_gk,
   int K = dim_w[1];
   
   int idx = 0;
-  float w = 0;
-  float th = 0;
+  double w = 0;
+  double th = 0;
   // NumericVector phi_b_gk (G*K);
   // phi_b_gk.attr("dim") = NumericVector::create(G,K);
   for(int k=0; k<K; ++k){

--- a/src/rcpp_retrofit_step4.cpp
+++ b/src/rcpp_retrofit_step4.cpp
@@ -5,9 +5,9 @@ using namespace Rcpp;
 List retrofit_step4_alpha_calculation(NumericVector x_gs, 
                                       NumericVector phi_a_gks, 
                                       NumericVector phi_b_gk, 
-                                      float alpha_w_0,
-                                      float alpha_h_0,
-                                      float alpha_th_0) {
+                                      double alpha_w_0,
+                                      double alpha_h_0,
+                                      double alpha_th_0) {
   /* Equivalent code
    * for(k in 1:K){
    *  alpha_W_gk[,k]= alpha_W_0 + rowSums(x*phi_a_gks[,k,])*phi_b_gk[,k])
@@ -25,9 +25,9 @@ List retrofit_step4_alpha_calculation(NumericVector x_gs,
   NumericVector alpha_w (G*K);
   NumericVector alpha_h (K*S);
   NumericVector alpha_th (K);
-  float x_gs_val;
-  float phi_a_gks_val;
-  float phi_b_gk_val;
+  double x_gs_val;
+  double phi_a_gks_val;
+  double phi_b_gk_val;
   NumericVector::iterator phi_a_gks_iter = phi_a_gks.begin();
   NumericVector::iterator phi_b_gk_iter = phi_b_gk.begin();
   NumericVector::iterator x_gs_iter = x_gs.begin();
@@ -86,10 +86,10 @@ List retrofit_step4_alpha_calculation(NumericVector x_gs,
 List retrofit_step4_beta_calculation(NumericVector W_gk,
                                      NumericVector H_ks,
                                      NumericVector TH_k,
-                                     float beta_w_0,
-                                     float beta_h_0,
-                                     float beta_th_0,
-                                     float lambda)
+                                     double beta_w_0,
+                                     double beta_h_0,
+                                     double beta_th_0,
+                                     double lambda)
 {
   /* Equivalent code
    * for(k in 1:K){

--- a/src/rcpp_retrofit_step5.cpp
+++ b/src/rcpp_retrofit_step5.cpp
@@ -4,7 +4,7 @@ using namespace Rcpp;
 // [[Rcpp::export]]
 NumericVector retrofit_step5_parameter_estimation(NumericVector original, 
                                                   NumericVector update, 
-                                                  float rho) {
+                                                  double rho) {
   
   NumericVector ret (original.length());
   for(int i=0; i<original.length(); ++i){

--- a/tests/testthat/test-refactoring-reproducibility.R
+++ b/tests/testthat/test-refactoring-reproducibility.R
@@ -1,8 +1,8 @@
 test_that("reproducibility", {
   dir = "~/Research/retrofit/retrofit/results"
   file="A3_1554"
-  paths_original = retrofit_simulation_original(dir, file, iterations=10)
-  paths = retrofit_simulation(dir, file, iterations=10)
+  paths_original = retrofit_simulation_original(dir, file, iterations=100)
+  paths = retrofit_simulation(dir, file, iterations=100)
   
   w_original=read.csv(paths_original$out_w_path)
   h_original=read.csv(paths_original$out_h_path)
@@ -12,7 +12,7 @@ test_that("reproducibility", {
   h=read.csv(paths$out_h_path)
   t=read.csv(paths$out_t_path)
   
-  expect_true(all.equal(w_original, w, tolerance=1e-4))
-  expect_true(all.equal(h_original, h, tolerance=1e-4))
-  expect_true(all.equal(t_original, t, tolerance=1e-4))
+  expect_true(all.equal(w_original, w))
+  expect_true(all.equal(h_original, h))
+  expect_true(all.equal(t_original, t))
 })

--- a/tests/testthat/test-refactoring-retrofit-step3.R
+++ b/tests/testthat/test-refactoring-retrofit-step3.R
@@ -2,9 +2,9 @@ test_that("step3-alpha-numerator", {
   G = 4
   K = 3
   S = 2
-  # G = 1550
-  # K = 16
-  # S = 1080
+  G = 1550
+  K = 16
+  S = 1080
   W_gk=matrix(runif(G*K, 0, 10),nrow=G, ncol=K)
   H_ks=matrix(runif(K*S, 0, 10),nrow=K, ncol=S)
   TH_k=array(runif(K, 0, 10))
@@ -27,16 +27,16 @@ test_that("step3-alpha-numerator", {
   retrofit_step3_alpha_numerator(W_gk, TH_k, H_ks, lambda, phi_a_gks_new);
   print(paste('rcpp: ', paste0(round(as.numeric(difftime(time1 = Sys.time(), time2 = from, units = "secs")), 3), " Seconds")))
   
-  expect_true(all.equal(phi_a_gks, phi_a_gks_new, tolerance=1e-4))
+  expect_true(all.equal(phi_a_gks, phi_a_gks_new))
 })
 
 test_that("step3-alpha-denominator", {
   G = 4
   K = 3
   S = 2
-  # G = 1550
-  # K = 16
-  # S = 1080
+  G = 1550
+  K = 16
+  S = 1080
   phi_a_gks = array(runif(G*K*S, 0, 10), c(G,K,S))
   phi_a_gks_new <- phi_a_gks
   
@@ -55,14 +55,14 @@ test_that("step3-alpha-denominator", {
   print(paste('rcpp: ', paste0(round(as.numeric(difftime(time1 = Sys.time(), time2 = from, units = "secs")), 3), " Seconds")))
   
   # test: all elements are same
-  expect_true(all.equal(phi_a_gks, phi_a_gks_new, tolerance=1e-4))
+  expect_true(all.equal(phi_a_gks, phi_a_gks_new))
 })
 
 test_that("step3-beta", {
   G = 4
   K = 3
-  # G = 1550
-  # K = 16
+  G = 1550
+  K = 16
   W_gk=matrix(runif(G*K, 0, 10),nrow=G, ncol=K)
   TH_k=array(runif(K, 0, 10))
   lambda = runif(1, 0, 1)
@@ -87,7 +87,7 @@ test_that("step3-beta", {
   retrofit_step3_beta(W_gk, TH_k, lambda, phi_b_gk_new);
   # print(paste('rcpp: ', paste0(round(as.numeric(difftime(time1 = Sys.time(), time2 = from, units = "secs")), 3), " Seconds")))
   
-  expect_true(all.equal(phi_b_gk, phi_b_gk_new, tolerance=1e-4))
+  expect_true(all.equal(phi_b_gk, phi_b_gk_new))
 })
 
 
@@ -95,9 +95,9 @@ test_that("step3-alpha", {
   G = 4
   K = 3
   S = 2
-  # G = 1550
-  # K = 16
-  # S = 1080
+  G = 1550
+  K = 16
+  S = 1080
   W_gk=matrix(runif(G*K, 0, 10),nrow=G, ncol=K)
   H_ks=matrix(runif(K*S, 0, 10),nrow=K, ncol=S)
   TH_k=array(runif(K, 0, 10))
@@ -123,7 +123,7 @@ test_that("step3-alpha", {
   retrofit_step3_alpha(W_gk, TH_k, H_ks, lambda, phi_a_gks_new);
   print(paste('rcpp: ', paste0(round(as.numeric(difftime(time1 = Sys.time(), time2 = from, units = "secs")), 3), " Seconds")))
   
-  expect_true(all.equal(phi_a_gks, phi_a_gks_new, tolerance=1e-4))
+  expect_true(all.equal(phi_a_gks, phi_a_gks_new))
 })
 
 

--- a/tests/testthat/test-refactoring-retrofit-step4.R
+++ b/tests/testthat/test-refactoring-retrofit-step4.R
@@ -38,9 +38,9 @@ test_that("step4_alpha", {
   print(paste('rcpp-code: ', paste0(round(as.numeric(difftime(time1 = Sys.time(), time2 = from, units = "secs")), 3), " Seconds")))
   
   
-  expect_true(all.equal(alpha_w_gk, alpha_w_gk_new, tolerance=1e-4))
-  expect_true(all.equal(alpha_h_ks, alpha_h_ks_new, tolerance=1e-4))
-  expect_true(all.equal(alpha_th_k, alpha_th_k_new, tolerance=1e-4))
+  expect_true(all.equal(alpha_w_gk, alpha_w_gk_new))
+  expect_true(all.equal(alpha_h_ks, alpha_h_ks_new))
+  expect_true(all.equal(alpha_th_k, alpha_th_k_new))
 })
 
 test_that("step4_beta", {
@@ -84,7 +84,7 @@ test_that("step4_beta", {
   beta_th_k_new = ret$t
   print(paste('rcpp-code: ', paste0(round(as.numeric(difftime(time1 = Sys.time(), time2 = from, units = "secs")), 3), " Seconds")))
 
-  expect_true(all.equal(beta_w_gk, beta_w_gk_new, tolerance=1e-4))
-  expect_true(all.equal(beta_h_ks, beta_h_ks_new, tolerance=1e-4))
-  expect_true(all.equal(beta_th_k, beta_th_k_new, tolerance=1e-4))
+  expect_true(all.equal(beta_w_gk, beta_w_gk_new))
+  expect_true(all.equal(beta_h_ks, beta_h_ks_new))
+  expect_true(all.equal(beta_th_k, beta_th_k_new))
 })

--- a/tests/testthat/test-refactoring-retrofit-step5.R
+++ b/tests/testthat/test-refactoring-retrofit-step5.R
@@ -2,6 +2,9 @@ test_that("step5-alpha-updates", {
   G = 4
   K = 3
   S = 2
+  G = 1550
+  K = 16
+  S = 1080
   W_gk=matrix(runif(G*K, 0, 10),nrow=G, ncol=K)
   W_gk_updated=matrix(runif(G*K, 0, 10),nrow=G, ncol=K)
   H_ks=matrix(runif(K*S, 0, 10),nrow=K, ncol=S)
@@ -25,7 +28,7 @@ test_that("step5-alpha-updates", {
   alpha_H_ks_new = array(retrofit_step5_parameter_estimation(H_ks, H_ks_updated, rho), c(K,S))
   alpha_TH_k_new = array(retrofit_step5_parameter_estimation(TH_k, TH_k_updated, rho), c(K))
   
-  expect_true(all.equal(alpha_W_gk, alpha_W_gk_new, tolerance=1e-4))
-  expect_true(all.equal(alpha_H_ks, alpha_H_ks_new, tolerance=1e-4))
-  expect_true(all.equal(alpha_TH_k, alpha_TH_k_new, tolerance=1e-4))
+  expect_true(all.equal(alpha_W_gk, alpha_W_gk_new))
+  expect_true(all.equal(alpha_H_ks, alpha_H_ks_new))
+  expect_true(all.equal(alpha_TH_k, alpha_TH_k_new))
 })


### PR DESCRIPTION
R uses double as a default type for real number.
However, I used float for real number variables in Rcpp functions.
Since the precision level is higher for double, the slight differences occurred whenever I use the float variables.
All those cases are fixed.